### PR TITLE
Group order

### DIFF
--- a/GroupOrderDebug.Rmd
+++ b/GroupOrderDebug.Rmd
@@ -1,0 +1,117 @@
+---
+title: "Example_Word"
+author: "Boyi Guo"
+date: "6/26/2019"
+output: word_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = F, message = F, warning = F)
+```
+
+```{r example}
+
+#devtools::install_github('boyiguo1/KableOne')
+
+library(labelled)
+library(tidyverse)
+library(magrittr)
+library(survival)
+library(kableExtra)
+library(KableOne)
+library(flextable)
+library(officer)
+
+
+#source("R/to_word.R")
+
+
+data = pbc %>%
+  dplyr::select(
+    age, sex, trt, stage, ascites, bili, edema, albumin, status
+  ) %>%
+  dplyr::mutate(
+    status=factor(
+      status, levels = c(0:2),
+      labels = c("Censored", "Transplant", "Dead")
+    ),
+    stage = factor(
+      stage, levels = c(1:4),
+      labels = c("One", "Two", "Three", "Four")
+    ),
+    trt=factor(
+      trt, levels=c(1:2),
+      labels = c("Drug A", "Drug B")
+    ),
+    ascites=factor(
+      ascites, levels=c(0:1),
+      labels = c("No", "Yes")
+    ),
+    sex = fct_recode(
+      sex,
+      'Male'='m',
+      'Female'='f'
+    ),
+    edema = factor(
+      edema,
+      levels=c(0, 0.5, 1),
+      labels=c("None", "A little", "Lots")
+    )
+  ) 
+
+
+data = data %>%
+  set_variable_labels(
+    status = "Status at last contact",
+    trt = "Treatment group",
+    age = 'Age, years',
+    sex = 'Sex at birth',
+    ascites = 'Ascites',
+    bili = 'Bilirubin levels, mg/dl',
+    edema = 'Is there Edema?'
+  ) %>%
+  set_variable_groups(
+    Outcomes = c('status'),
+    Exposures = c('ascites','bili','edema','trt','albumin','stage')
+  ) 
+```
+
+```{r}
+
+tbl_one = data %>%
+  tibble_one(
+    formula = ~ . | trt,
+    include.allcats = FALSE,
+    include.freq = FALSE,
+    include.pval = TRUE
+  )
+
+```
+# With groups example
+```{r}
+
+tmp <- tbl_one %>% 
+  to_word(
+    use_groups = T,
+    apply_format_steps = T
+    )
+
+tmp 
+```
+
+\newpage
+# Without groups example
+```{r}
+
+# TODO(boyiguo1): Fix the bug that when use_groups, all the first column are bolded, should relate to the use of bold function
+  
+  
+tmp <- tbl_one %>% 
+  to_word(
+    use_groups = FALSE,
+    apply_format_steps = T
+    )
+
+tmp 
+```
+

--- a/GroupOrderDebug.Rmd
+++ b/GroupOrderDebug.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "Example_Word"
+title: "GroupOrderDebug"
 author: "Boyi Guo"
-date: "6/26/2019"
+date: "7/27/2019"
 output: word_document
 ---
 
@@ -9,9 +9,9 @@ output: word_document
 knitr::opts_chunk$set(echo = F, message = F, warning = F)
 ```
 
-```{r example}
-
-#devtools::install_github('boyiguo1/KableOne')
+```{r Data Prep}
+# Install current branch from Github
+# devtools::install_github('boyiguo1/KableOne', ref = "Group-Order")
 
 library(labelled)
 library(tidyverse)
@@ -22,10 +22,7 @@ library(KableOne)
 library(flextable)
 library(officer)
 
-
-#source("R/to_word.R")
-
-
+# Prepare data
 data = pbc %>%
   dplyr::select(
     age, sex, trt, stage, ascites, bili, edema, albumin, status
@@ -59,59 +56,108 @@ data = pbc %>%
     )
   ) 
 
-
-data = data %>%
-  set_variable_labels(
-    status = "Status at last contact",
-    trt = "Treatment group",
-    age = 'Age, years',
-    sex = 'Sex at birth',
-    ascites = 'Ascites',
-    bili = 'Bilirubin levels, mg/dl',
-    edema = 'Is there Edema?'
-  ) %>%
-  set_variable_groups(
-    Outcomes = c('status'),
-    Exposures = c('ascites','bili','edema','trt','albumin','stage')
-  ) 
+# Ignored due to simplicity
+# data = data %>%
+#   set_variable_labels(
+#     status = "Status at last contact",
+#     trt = "Treatment group",
+#     age = 'Age, years',
+#     sex = 'Sex at birth',
+#     ascites = 'Ascites',
+#     bili = 'Bilirubin levels, mg/dl',
+#     edema = 'Is there Edema?'
+#   ) 
 ```
 
-```{r}
 
-tbl_one = data %>%
+# Without Groups
+## Base Case
+Expectation: We are expecting the order of the vairables follows the same order as speficied in the the formula.
+```{r}
+data %>% 
   tibble_one(
     formula = ~ . | trt,
     include.allcats = FALSE,
     include.freq = FALSE,
     include.pval = TRUE
-  )
-
+  ) %>% to_word
 ```
-# With groups example
-```{r}
 
-tmp <- tbl_one %>% 
-  to_word(
-    use_groups = T,
-    apply_format_steps = T
+
+# With Groups
+```{r}
+data.1 <- data %>%
+  set_variable_groups(
+    Outcomes = c('status'),
+    Exposures = c('ascites','bili','edema','trt','albumin','stage')
+  ) 
+```
+## Groups are assigned but not used when creating table
+Expectation: The same result as in _Without Groups: Base Case_.
+```{r}
+data.1 %>% 
+  tibble_one(
+    formula = ~ . | trt,
+    include.allcats = FALSE,
+    include.freq = FALSE,
+    include.pval = TRUE
+  ) %>% to_word(use_groups = F)
+```
+Solution: move the use_groups argument from __to_word__ to __tibble_one__ so that we know how to set the level order in __tibble_one__
+
+## Groups are assigned and used when creating table
+Epectation: The same order as specified in group, with variables not specified at the top of the table
+```{r}
+data.1 %>% 
+  tibble_one(
+    formula = ~ . | trt,
+    include.allcats = FALSE,
+    include.freq = FALSE,
+    include.pval = TRUE
+  ) %>% to_word()
+```
+
+
+## One variable in different groups
+Expectation: order as the same as specified. Variable group will be updated based on its last appearance in any groups. Meanwhile, a warning message shows that indicates which variable is updated.
+```{r}
+data.2 <- data %>%
+  set_variable_groups(
+    Outcomes = c('status', 'stage'),
+    Exposures = c('ascites','bili','edema','trt','albumin','stage')
+  ) 
+
+data.2 %>% 
+  tibble_one(
+    formula = ~ . | trt,
+    include.allcats = FALSE,
+    include.freq = FALSE,
+    include.pval = TRUE
+  ) %>% to_word()
+```
+
+
+
+# With Multiple Group Assignment
+Expectation: same as if in one call to __set_variable_groups__
+```{r}
+data.3 <- data %>%
+  set_variable_groups(
+    Outcomes = c('status', 'stage')
+  ) 
+data.3 <- data.3 %>% 
+  set_variable_groups(
+    Exposures = c('ascites','bili','edema','trt','albumin','stage')
     )
 
-tmp 
+data.3 %>% 
+  tibble_one(
+    formula = ~ . | trt,
+    include.allcats = FALSE,
+    include.freq = FALSE,
+    include.pval = TRUE
+  ) %>% to_word()
 ```
 
-\newpage
-# Without groups example
-```{r}
 
-# TODO(boyiguo1): Fix the bug that when use_groups, all the first column are bolded, should relate to the use of bold function
-  
-  
-tmp <- tbl_one %>% 
-  to_word(
-    use_groups = FALSE,
-    apply_format_steps = T
-    )
-
-tmp 
-```
 

--- a/R/set_variable_groups.R
+++ b/R/set_variable_groups.R
@@ -9,31 +9,49 @@
 
 
 # data = data
-input_values <- list(Outcomes = c('status'),
-  Exposures = c('ascites','bili','edema','trt','albumin','stage'))
+# input_values <- list(Outcomes = c('status', 'stage'),
+#   Exposures = c('ascites','bili','edema','trt','albumin','stage'))
 #
 
 set_variable_groups <- function(data, ...){
 
   input_values <- list(...)
 
-  .names <- .values <- vector(
-    mode='character',
-    length=length(unlist(input_values))
-  )
+  # .names <- .values <- vector(
+  #   mode='character',
+  #   length=length(unlist(input_values))
+  # )
 
-  counter=1
+  values <- list()
+
+  # counter=1
   for(i in 1:length(input_values)){
+    if(any(input_values[[i]] %in% names(values))){
+      ext.vars <- intersect(input_values[[i]], names(values))
+      warning(paste("Updating Group(s) for Variable", ext.vars))
+      values[ext.vars] <- NULL
+    }
+
     for(j in 1:length(input_values[[i]])){
-      .names[counter] <- input_values[[i]][j]
-      .values[counter] <- names(input_values)[i]
-      counter=counter+1
+      values[input_values[[i]][j]] <- names(input_values)[i]
+      # .names[counter] <- input_values[[i]][j]
+      # .values[counter] <- names(input_values)[i]
+      # counter=counter+1
     }
   }
 
-  values <- .values %>%
-    as.list() %>%
-    magrittr::set_names(.names)
+  # values <- .values %>%
+  #   as.list() %>%
+  #   magrittr::set_names(.names)
+
+  # Solution 1 : following the same order as appearance
+  # if(!is.null(attr(data, "var_levels", exact = T)))
+  #   values <- values[!(names(values) %in% attr(data, "var_levels", exact = T))]
+
+  # Solution 2: update
+   if(!is.null(attr(data, "var_levels", exact = T)))
+     attr(data, "var_levels") <- setdiff(attr(data, "var_levels", exact = T), names(values))
+
 
   if (length(values) > 0) {
     if (!all(names(values) %in% names(data)))
@@ -45,16 +63,16 @@ set_variable_groups <- function(data, ...){
 
   # Create Group Levels
   if(is.null(attr(data, "group_levels", exact = T))) {
-    attr(data, "group_levels") <- c("None", unique(.values))
+    attr(data, "group_levels") <- c("None", unique(unlist(values)))
   } else {
-    attr(data, "group_levels") <- unique(c("None", attr(data, "group_levels", exact = T), .values))
+    attr(data, "group_levels") <- unique(c("None", attr(data, "group_levels", exact = T), unlist(values)))
   }
 
   # Create Variable Levels
   if(is.null(attr(data, "var_levels", exact = T))) {
-    attr(data, "var_levels") <- unique(.names)
+    attr(data, "var_levels") <- unique(names(values))
   } else {
-    attr(data, "var_levels") <- unique(c(attr(data, "var_levels", exact = T), .names))
+    attr(data, "var_levels") <- unique(c(attr(data, "var_levels", exact = T), names(values)))
   }
 
 

--- a/R/set_variable_groups.R
+++ b/R/set_variable_groups.R
@@ -31,9 +31,6 @@ set_variable_groups <- function(data, ...){
     }
   }
 
-
-  # TODO(boyiguo1): Add the level of previous group attr in.
-
   values <- .values %>%
     as.list() %>%
     magrittr::set_names(.names)
@@ -46,11 +43,20 @@ set_variable_groups <- function(data, ...){
     }
   }
 
+  # Create Group Levels
   if(is.null(attr(data, "group_levels", exact = T))) {
     attr(data, "group_levels") <- c("None", unique(.values))
   } else {
     attr(data, "group_levels") <- unique(c("None", attr(data, "group_levels", exact = T), .values))
   }
+
+  # Create Variable Levels
+  if(is.null(attr(data, "var_levels", exact = T))) {
+    attr(data, "var_levels") <- unique(.names)
+  } else {
+    attr(data, "var_levels") <- unique(c(attr(data, "var_levels", exact = T), .names))
+  }
+
 
   data
 }

--- a/R/set_variable_groups.R
+++ b/R/set_variable_groups.R
@@ -7,6 +7,12 @@
 #' @export
 #' @importFrom magrittr '%>%' 'set_names'
 
+
+# data = data
+input_values <- list(Outcomes = c('status'),
+  Exposures = c('ascites','bili','edema','trt','albumin','stage'))
+#
+
 set_variable_groups <- function(data, ...){
 
   input_values <- list(...)
@@ -25,6 +31,9 @@ set_variable_groups <- function(data, ...){
     }
   }
 
+
+  # TODO(boyiguo1): Add the level of previous group attr in.
+
   values <- .values %>%
     as.list() %>%
     magrittr::set_names(.names)
@@ -36,8 +45,14 @@ set_variable_groups <- function(data, ...){
       attr(data[[v]], "group") <- values[[v]]
     }
   }
-  data
 
+  if(is.null(attr(data, "group_levels", exact = T))) {
+    attr(data, "group_levels") <- c("None", unique(.values))
+  } else {
+    attr(data, "group_levels") <- unique(c("None", attr(data, "group_levels", exact = T), .values))
+  }
+
+  data
 }
 
 #' get the group attribute of a variable

--- a/R/tibble_one.R
+++ b/R/tibble_one.R
@@ -465,8 +465,12 @@ tibble_one <- function(
     ) %>%
     mutate(
       variable = factor(variable, levels = c('descr', row.vars)),
-      group = factor(group),
-      group = fct_relevel(group, 'None'),
+      group = factor(group,
+                     levels = unique(
+                       c("None", attr(tbl_data, "group_levels", exact = T))
+                       )
+                     ),
+      #group = fct_relevel(group, 'None'),
       labels = case_when(
         !is.na(unit) ~ paste(labels, unit, sep = ', '),
         TRUE ~ labels

--- a/R/tibble_one.R
+++ b/R/tibble_one.R
@@ -464,7 +464,11 @@ tibble_one <- function(
       .
     ) %>%
     mutate(
-      variable = factor(variable, levels = c('descr', row.vars)),
+      variable = factor(variable,
+                        levels = c('descr',
+                                    unique(c(attr(tbl_data, "var_levels", exact = T), row.vars))
+                                   )
+                        ),
       group = factor(group,
                      levels = unique(
                        c("None", attr(tbl_data, "group_levels", exact = T))

--- a/R/tibble_one.R
+++ b/R/tibble_one.R
@@ -466,7 +466,12 @@ tibble_one <- function(
     mutate(
       variable = factor(variable,
                         levels = c('descr',
-                                    unique(c(attr(tbl_data, "var_levels", exact = T), row.vars))
+                                    unique(
+                                      c(
+                                        setdiff(row.vars, attr(tbl_data, "var_levels", exact = T)), # order for variables without group assignment
+                                        attr(tbl_data, "var_levels", exact = T), # Order for variables with group assignment
+                                        row.vars)
+                                      )
                                    )
                         ),
       group = factor(group,


### PR DESCRIPTION
I improved the functions __set_variable_groups__ and __tibble_one__, such that the group order is not pseudo-alphabetic any more. Instead, it is following the same order specified within __set_variable_groups__.

Ordering Rule:
*  Variables  without any group specification are ordered as in the __tibble_one__ _formula_ / in the input dataset
* Variables with group specifications are ordered as specified in __set_variable_groups__, along with group order.
* When a variable is grouped multiple times within one call or multiple calls to __set_variable_groups__ , it belongs to the latest group, and hence ordered the same way in the latest call to __set_variable_groups__ . 
* Variables without group specification are prioritized over variable with group specification, and hence shows at the top of the table.

Implementation:
1. adding attribute __group_levels__, __var_levels__ as attribute to the data(frame) when calling __set_variable_groups__.
2. In __tibble_one__, when _group_ and _variable_ mutate to factor variables from character variables, the order will add as the format of levels, and hence `arrange` accordingly.